### PR TITLE
Use log4j 2.16.0 to avoid vulnerability: https://cve.mitre.org/cgi-bi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,19 @@
             <version>2.11.3</version>
         </dependency>
 
+        <!-- Avoid log4j vulnerability -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.16.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.16.0</version>
+        </dependency>
+
         <!-- Compile-time -->
 
         <dependency>


### PR DESCRIPTION
…n/cvename.cgi?name=CVE-2021-44228