### PR TITLE
update AWS SDK to v2

### DIFF
--- a/config/local/logback.xml
+++ b/config/local/logback.xml
@@ -24,7 +24,7 @@
 	<logger name="org.eclipse.jetty" level="WARN" />
 	<logger name="com.google.inject" level="WARN" />
 	<logger name="com.zaxxer" level="WARN" />
-	<logger name="com.amazonaws" level="ERROR" />
+	<logger name="software.amazon.awssdk" level="ERROR" />
 	<logger name="org.apache" level="ERROR" />
 	<logger name="com.github.jknack.handlebars" level="WARN" />
 	<logger name="org.postgresql" level="INFO" />

--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.12.141</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.15.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -170,19 +170,19 @@
             <version>3.0.5</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+          <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+
+         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-ses</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ses</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/cobaltplatform/api/AppModule.java
+++ b/src/main/java/com/cobaltplatform/api/AppModule.java
@@ -469,7 +469,6 @@ public class AppModule extends AbstractModule {
 
 		return new EmailMessageManager(accountServiceProvider, database, configuration, formatter, messageSender, messageSerializer, (processingFunction) -> {
 			return new AmazonSqsManager.Builder(getConfiguration().getAmazonSqsEmailMessageQueueName(),
-					getConfiguration().getAmazonCredentialsProvider(),
 					getConfiguration().getAmazonSqsRegion())
 					.useLocalstack(getConfiguration().getAmazonUseLocalstack())
 					.localstackPort(getConfiguration().getAmazonLocalstackPort())
@@ -521,7 +520,6 @@ public class AppModule extends AbstractModule {
 
 		return new SmsMessageManager(accountServiceProvider, database, configuration, formatter, messageSender, messageSerializer, (processingFunction) -> {
 			return new AmazonSqsManager.Builder(getConfiguration().getAmazonSqsSmsMessageQueueName(),
-					getConfiguration().getAmazonCredentialsProvider(),
 					getConfiguration().getAmazonSqsRegion())
 					.useLocalstack(getConfiguration().getAmazonUseLocalstack())
 					.localstackPort(getConfiguration().getAmazonLocalstackPort())
@@ -575,7 +573,6 @@ public class AppModule extends AbstractModule {
 
 		return new CallMessageManager(accountServiceProvider, database, configuration, formatter, messageSender, messageSerializer, (processingFunction) -> {
 			return new AmazonSqsManager.Builder(getConfiguration().getAmazonSqsCallMessageQueueName(),
-					getConfiguration().getAmazonCredentialsProvider(),
 					getConfiguration().getAmazonSqsRegion())
 					.useLocalstack(getConfiguration().getAmazonUseLocalstack())
 					.localstackPort(getConfiguration().getAmazonLocalstackPort())


### PR DESCRIPTION
AWS SDK v2 has more advanced detection of the running environment (ECS,
EC2, etc) and it is recommended to pull credentials from the default
provider chain.

https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html

All functionality should be maintained.

Note the explicit expiration of presigned S3 object requsts. In the V1
SDK, not setting an expiration resulted in a default 15 minute
expiration time. It is not possible to set no expiration time for
presigned requests.

https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java#L3469