### PR TITLE
Introduce `previouslyAnswered` flag for screening context so UI knows…

### DIFF
--- a/src/main/java/com/cobaltplatform/api/service/ScreeningService.java
+++ b/src/main/java/com/cobaltplatform/api/service/ScreeningService.java
@@ -739,6 +739,20 @@ public class ScreeningService {
 	}
 
 	@Nonnull
+	public Boolean hasPreviouslyAnsweredQuestionInScreeningSessionScreening(@Nullable UUID screeningQuestionId,
+																																					@Nullable UUID screeningSessionScreeningId) {
+		if (screeningQuestionId == null || screeningSessionScreeningId == null)
+			return false;
+
+		return getDatabase().queryForObject("""
+				SELECT COUNT(*)
+				FROM screening_session_answered_screening_question
+				WHERE screening_session_screening_id=?
+				AND screening_question_id=?
+				""", Integer.class, screeningSessionScreeningId, screeningQuestionId).get() > 0;
+	}
+
+	@Nonnull
 	public List<UUID> createScreeningAnswers(@Nullable CreateScreeningAnswersRequest request) {
 		requireNonNull(request);
 

--- a/src/main/java/com/cobaltplatform/api/web/resource/ScreeningResource.java
+++ b/src/main/java/com/cobaltplatform/api/web/resource/ScreeningResource.java
@@ -347,6 +347,13 @@ public class ScreeningResource {
 		ScreeningConfirmationPromptApiResponse preQuestionScreeningConfirmationPromptApiResponse = preQuestionScreeningConfirmationPrompt == null ? null
 				: getScreeningConfirmationPromptApiResponseFactory().create(preQuestionScreeningConfirmationPrompt);
 
+		// UI might want to take special action if this question has been previously answered.
+		// We need an explicit flag here because for questions that have a minimum of 0 answers - skippable questions -
+		// we need to know that the question was "answered" with no answers.
+		boolean previouslyAnswered = getScreeningService().hasPreviouslyAnsweredQuestionInScreeningSessionScreening(
+				screeningQuestionContext.getScreeningQuestion().getScreeningQuestionId(),
+				screeningQuestionContext.getScreeningSessionScreening().getScreeningSessionScreeningId());
+
 		return new ApiResponse(new HashMap<String, Object>() {{
 			put("previousScreeningQuestionContextId", previousScreeningQuestionContext == null ? null
 					: previousScreeningQuestionContext.getScreeningQuestionContextId());
@@ -360,6 +367,7 @@ public class ScreeningResource {
 			put("screeningSessionDestination", screeningSessionDestination);
 			put("screeningFlowVersion", getScreeningFlowVersionApiResponseFactory().create(screeningFlowVersion));
 			put("preQuestionScreeningConfirmationPrompt", preQuestionScreeningConfirmationPromptApiResponse);
+			put("previouslyAnswered", previouslyAnswered);
 		}});
 	}
 


### PR DESCRIPTION
… if a question has already been answered, even in the event of 0 answers (skippable questions).