### PR TITLE
Be very conservative with message-sending and cleanup to avoid resend…

### DIFF
--- a/src/main/java/com/cobaltplatform/api/util/Formatter.java
+++ b/src/main/java/com/cobaltplatform/api/util/Formatter.java
@@ -646,12 +646,12 @@ public final class Formatter {
 	}
 
 	@Nonnull
-	public String formatStackTrace(@Nonnull Exception exception) {
-		requireNonNull(exception);
+	public String formatStackTrace(@Nonnull Throwable throwable) {
+		requireNonNull(throwable);
 
 		StringWriter stringWriter = new StringWriter();
 		PrintWriter printWriter = new PrintWriter(stringWriter);
-		exception.printStackTrace(printWriter);
+		throwable.printStackTrace(printWriter);
 		return stringWriter.toString();
 	}
 


### PR DESCRIPTION
… "cycles".

Use `FOR UPDATE SKIP LOCKED` size of 1 so we commit sent messages quickly (this way webhooks always succeed when looking up messages by vendor ID) and spin in a loop picking off any more messages to send.