### PR TITLE
If a patient does not have a FHIR ID associated with their account in…

### DIFF
--- a/src/main/java/com/cobaltplatform/api/service/AppointmentService.java
+++ b/src/main/java/com/cobaltplatform/api/service/AppointmentService.java
@@ -352,6 +352,10 @@ public class AppointmentService {
 			EnterprisePlugin enterprisePlugin = getEnterprisePluginProvider().enterprisePluginForInstitutionId(institution.getInstitutionId());
 			EpicClient epicClient = enterprisePlugin.epicClientForBackendService().get();
 
+			// We don't have a FHIR ID associated with this account yet?  No results available
+			if (account.getEpicPatientFhirId() == null)
+				return List.of();
+
 			AppointmentSearchFhirStu3Request request = new AppointmentSearchFhirStu3Request();
 			request.setPatient(account.getEpicPatientFhirId());
 


### PR DESCRIPTION
… a FHIR institution, don't bother to call Epic to check for appointments