### PR TITLE
Modifying the /studies/generate-accounts endpoint to take a list of s…

### DIFF
--- a/messages/push/STUDY_CHECK_IN_REMINDER/en/body.hbs
+++ b/messages/push/STUDY_CHECK_IN_REMINDER/en/body.hbs
@@ -1,1 +1,0 @@
-Please come back and complete your next check-in.

--- a/messages/push/STUDY_CHECK_IN_REMINDER/en/title.hbs
+++ b/messages/push/STUDY_CHECK_IN_REMINDER/en/title.hbs
@@ -1,1 +1,0 @@
-It's time to check-in

--- a/src/main/java/com/cobaltplatform/api/messaging/push/PushMessageTemplate.java
+++ b/src/main/java/com/cobaltplatform/api/messaging/push/PushMessageTemplate.java
@@ -24,6 +24,5 @@ package com.cobaltplatform.api.messaging.push;
  */
 public enum PushMessageTemplate {
 	FREEFORM,
-	MICROINTERVENTION,
-	STUDY_CHECK_IN_REMINDER
+	MICROINTERVENTION
 }

--- a/src/main/java/com/cobaltplatform/api/model/api/request/CreateStudyAccountRequest.java
+++ b/src/main/java/com/cobaltplatform/api/model/api/request/CreateStudyAccountRequest.java
@@ -17,48 +17,41 @@
  * limitations under the License.
  */
 
-package com.cobaltplatform.api.model.service;
+package com.cobaltplatform.api.model.api.request;
+
+import com.cobaltplatform.api.model.db.Role.RoleId;
+import com.cobaltplatform.api.model.db.Study;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.List;
 import java.util.UUID;
 
 /**
- * @author Transmogrify, LLC.
+ * @author Transmogrify LLC.
  */
-@ThreadSafe
-public class StudyAccount {
+@NotThreadSafe
+public class CreateStudyAccountRequest {
 	@Nullable
-	private UUID accountId;
+	private Integer participantCount;
 	@Nullable
-	private String username;
-	@Nullable
-	private String password;
+	private List<UUID> studyIds;
 
 	@Nullable
-	public UUID getAccountId() {
-		return accountId;
+	public Integer getParticipantCount() {
+		return participantCount;
 	}
 
-	public void setAccountId(@Nullable UUID accountId) {
-		this.accountId = accountId;
-	}
-
-	@Nullable
-	public String getUsername() {
-		return username;
-	}
-
-	public void setUsername(@Nullable String username) {
-		this.username = username;
+	public void setParticipantCount(@Nullable Integer participantCount) {
+		this.participantCount = participantCount;
 	}
 
 	@Nullable
-	public String getPassword() {
-		return password;
+	public List<UUID> getStudyIds() {
+		return studyIds;
 	}
 
-	public void setPassword(@Nullable String password) {
-		this.password = password;
+	public void setStudyIds(@Nullable List<UUID> studyIds) {
+		this.studyIds = studyIds;
 	}
 }

--- a/src/main/java/com/cobaltplatform/api/model/db/StudyCheckInAction.java
+++ b/src/main/java/com/cobaltplatform/api/model/db/StudyCheckInAction.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2021 The University of Pennsylvania and Penn Medicine
+ *
+ * Originally created at the University of Pennsylvania and Penn Medicine by:
+ * Dr. David Asch; Dr. Lisa Bellini; Dr. Cecilia Livesey; Kelley Kugler; and Dr. Matthew Press.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cobaltplatform.api.model.db;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * @author Transmogrify, LLC.
+ */
+@NotThreadSafe
+public class StudyCheckInAction {
+	@Nullable
+	private UUID studyCheckInActionId;
+	@Nullable
+	private UUID studyCheckInId;
+	@Nullable
+	private CheckInType checkInType;
+	@Nullable
+	private Integer actionOrder;
+	@Nullable
+	private UUID screeningFlowId;
+	@Nullable
+	private String videoPrompt;
+	@Nullable
+	private String videoScript;
+	@Nullable
+	private String videoIntro;
+	@Nullable
+	private Integer minVideoTimeSeconds;
+	@Nullable
+	private Integer maxVideoTimeSeconds;
+	@Nullable
+	private Boolean sendFollowupNotification;
+	@Nullable
+	private Integer followupNotificationMinutes;
+	@Nullable
+	private String followupNotificationMessageTitle;
+	@Nullable
+	private String followupNotificationMessageBody;
+	@Nullable
+	private String recordingTypePrompt;
+	@Nullable
+	private String audioPrompt;
+	@Nullable
+	private Instant created;
+	@Nullable
+	private Instant lastUpdated;
+
+	@Nullable
+	public UUID getStudyCheckInActionId() {
+		return studyCheckInActionId;
+	}
+
+	public void setStudyCheckInActionId(@Nullable UUID studyCheckInActionId) {
+		this.studyCheckInActionId = studyCheckInActionId;
+	}
+
+	@Nullable
+	public UUID getStudyCheckInId() {
+		return studyCheckInId;
+	}
+
+	public void setStudyCheckInId(@Nullable UUID studyCheckInId) {
+		this.studyCheckInId = studyCheckInId;
+	}
+
+	@Nullable
+	public CheckInType getCheckInType() {
+		return checkInType;
+	}
+
+	public void setCheckInType(@Nullable CheckInType checkInType) {
+		this.checkInType = checkInType;
+	}
+
+	@Nullable
+	public Integer getActionOrder() {
+		return actionOrder;
+	}
+
+	public void setActionOrder(@Nullable Integer actionOrder) {
+		this.actionOrder = actionOrder;
+	}
+
+	@Nullable
+	public UUID getScreeningFlowId() {
+		return screeningFlowId;
+	}
+
+	public void setScreeningFlowId(@Nullable UUID screeningFlowId) {
+		this.screeningFlowId = screeningFlowId;
+	}
+
+	@Nullable
+	public String getVideoPrompt() {
+		return videoPrompt;
+	}
+
+	public void setVideoPrompt(@Nullable String videoPrompt) {
+		this.videoPrompt = videoPrompt;
+	}
+
+	@Nullable
+	public String getVideoScript() {
+		return videoScript;
+	}
+
+	public void setVideoScript(@Nullable String videoScript) {
+		this.videoScript = videoScript;
+	}
+
+	@Nullable
+	public String getVideoIntro() {
+		return videoIntro;
+	}
+
+	public void setVideoIntro(@Nullable String videoIntro) {
+		this.videoIntro = videoIntro;
+	}
+
+	@Nullable
+	public Integer getMinVideoTimeSeconds() {
+		return minVideoTimeSeconds;
+	}
+
+	public void setMinVideoTimeSeconds(@Nullable Integer minVideoTimeSeconds) {
+		this.minVideoTimeSeconds = minVideoTimeSeconds;
+	}
+
+	@Nullable
+	public Integer getMaxVideoTimeSeconds() {
+		return maxVideoTimeSeconds;
+	}
+
+	public void setMaxVideoTimeSeconds(@Nullable Integer maxVideoTimeSeconds) {
+		this.maxVideoTimeSeconds = maxVideoTimeSeconds;
+	}
+
+	@Nullable
+	public Boolean getSendFollowupNotification() {
+		return sendFollowupNotification;
+	}
+
+	public void setSendFollowupNotification(@Nullable Boolean sendFollowupNotification) {
+		this.sendFollowupNotification = sendFollowupNotification;
+	}
+
+	@Nullable
+	public Integer getFollowupNotificationMinutes() {
+		return followupNotificationMinutes;
+	}
+
+	public void setFollowupNotificationMinutes(@Nullable Integer followupNotificationMinutes) {
+		this.followupNotificationMinutes = followupNotificationMinutes;
+	}
+
+	@Nullable
+	public String getFollowupNotificationMessageTitle() {
+		return followupNotificationMessageTitle;
+	}
+
+	public void setFollowupNotificationMessageTitle(@Nullable String followupNotificationMessageTitle) {
+		this.followupNotificationMessageTitle = followupNotificationMessageTitle;
+	}
+
+	@Nullable
+	public String getFollowupNotificationMessageBody() {
+		return followupNotificationMessageBody;
+	}
+
+	public void setFollowupNotificationMessageBody(@Nullable String followupNotificationMessageBody) {
+		this.followupNotificationMessageBody = followupNotificationMessageBody;
+	}
+
+	@Nullable
+	public String getRecordingTypePrompt() {
+		return recordingTypePrompt;
+	}
+
+	public void setRecordingTypePrompt(@Nullable String recordingTypePrompt) {
+		this.recordingTypePrompt = recordingTypePrompt;
+	}
+
+	@Nullable
+	public String getAudioPrompt() {
+		return audioPrompt;
+	}
+
+	public void setAudioPrompt(@Nullable String audioPrompt) {
+		this.audioPrompt = audioPrompt;
+	}
+
+	@Nullable
+	public Instant getCreated() {
+		return created;
+	}
+
+	public void setCreated(@Nullable Instant created) {
+		this.created = created;
+	}
+
+	@Nullable
+	public Instant getLastUpdated() {
+		return lastUpdated;
+	}
+
+	public void setLastUpdated(@Nullable Instant lastUpdated) {
+		this.lastUpdated = lastUpdated;
+	}
+}

--- a/src/main/java/com/cobaltplatform/api/web/resource/StudyResource.java
+++ b/src/main/java/com/cobaltplatform/api/web/resource/StudyResource.java
@@ -21,6 +21,7 @@ package com.cobaltplatform.api.web.resource;
 
 import com.cobaltplatform.api.context.CurrentContext;
 import com.cobaltplatform.api.model.api.request.CreateAccountCheckInActionFileUploadRequest;
+import com.cobaltplatform.api.model.api.request.CreateStudyAccountRequest;
 import com.cobaltplatform.api.model.api.request.CreateStudyFileUploadRequest;
 import com.cobaltplatform.api.model.api.request.UpdateCheckInAction;
 import com.cobaltplatform.api.model.api.response.AccountCheckInApiResponse.AccountCheckInApiResponseFactory;
@@ -125,17 +126,15 @@ public class StudyResource {
 	}
 
 	@Nonnull
-	@POST("/studies/{studyId}/generate-accounts")
+	@POST("/studies/generate-accounts")
 	@AuthenticationRequired
-	public ApiResponse generateAccounts(@Nonnull @PathParameter UUID studyId,
-																			@Nonnull @QueryParameter Optional<Integer> count) {
-		requireNonNull(studyId);
-		requireNonNull(count);
+	public ApiResponse generateAccounts(@Nonnull @RequestBody String requestBody) {
+		requireNonNull(requestBody);
 
 		Account account = getCurrentContext().getAccount().get();
-		int finalCount = count.orElse(10);
+		CreateStudyAccountRequest request = getRequestBodyParser().parse(requestBody, CreateStudyAccountRequest.class);
 		return new ApiResponse(new HashMap<String, Object>() {{
-			put("accounts", getStudyService().generateAccountsForStudy(studyId, finalCount, account).stream().map(studyAccount ->
+			put("accounts", getStudyService().generateAccountsForStudies(request, account).stream().map(studyAccount ->
 					getStudyAccountApiResponseFactory().create(studyAccount)).collect(Collectors.toList()));
 		}});
 	}


### PR DESCRIPTION
…tudies in instead of just a single study id. Updated documentation can be found here: https://github.com/cobaltinnovations/cobalt-api-docs/wiki/Studies#post-studiesgenerate-accounts.

Also changing pus notification messages to be data driven.