### PR TITLE
Don't have `GET /integrated-care/panel-counts` use the read-replica j…

### DIFF
--- a/src/main/java/com/cobaltplatform/api/web/resource/PatientOrderResource.java
+++ b/src/main/java/com/cobaltplatform/api/web/resource/PatientOrderResource.java
@@ -1583,7 +1583,6 @@ public class PatientOrderResource {
 	@Nonnull
 	@GET("/integrated-care/panel-counts")
 	@AuthenticationRequired
-	@ReadReplica
 	public ApiResponse panelCounts(@Nonnull @QueryParameter Optional<UUID> panelAccountId) {
 		requireNonNull(panelAccountId);
 


### PR DESCRIPTION
…ust yet (FE does not call it often enough; it could get out of sync in the UI if replication lags)