### PR TITLE
Make sure to specify a country code for care resources (default to US…

### DIFF
--- a/src/main/java/com/cobaltplatform/api/service/CareResourceService.java
+++ b/src/main/java/com/cobaltplatform/api/service/CareResourceService.java
@@ -845,6 +845,7 @@ public class CareResourceService {
 			createAddressRequest.setFormattedAddress(place.getFormattedAddress());
 			createAddressRequest.setLatitude(place.getLocation().getLatitude());
 			createAddressRequest.setLongitude(place.getLocation().getLongitude());
+			createAddressRequest.setCountryCode("US"); // TODO: remove hardcoding if we expand outside of US
 
 			addressId = getAddressService().createAddress(createAddressRequest);
 		}


### PR DESCRIPTION
… while we are still US-only)